### PR TITLE
change z-index value

### DIFF
--- a/user_chrome/gnome-scrollbars.uc.js
+++ b/user_chrome/gnome-scrollbars.uc.js
@@ -32,7 +32,7 @@
 		box-sizing: border-box !important;
 		background-color: transparent;
 		background-image: none;
-		z-index: 1;
+		z-index: 2;
 		pointer-events: auto;
 		width: auto !important;
 		border-style: solid !important;


### PR DESCRIPTION
Increase z-index value so that scrollbar doesn't hide behind warning and error messages in browser console (Firefox Nightly 76.0a1 - 2020-03-27)